### PR TITLE
fixed fetch input file creation path (solving FileNotFoundError)

### DIFF
--- a/aoc_lube/__init__.py
+++ b/aoc_lube/__init__.py
@@ -14,7 +14,7 @@ import tomlkit
 
 from . import utils
 
-__all__ = ["setup_dir", "fetch", "submit", "utils"]
+__all__ = ["fetch", "setup_dir", "submit", "utils"]
 
 __version__ = "1.1.0"
 
@@ -25,7 +25,7 @@ if not CONFIG_DIR.exists():
 HEADERS = {
     "User-Agent": (
         f"github.com/salt-die/aoc_lube v{__version__} by salt-die@protonmail.com"
-    )
+    ),
 }
 SUBMISSIONS_FILE = "submissions.toml"
 TEMPLATE_FILE = Path(__file__).parent / "code_template.txt"
@@ -58,7 +58,7 @@ except FileNotFoundError:
         f"\n{BOLD}{RED}::WARNING::{RESET}\n\n"
         f"Token not found at {BLUE}{TOKEN_FILE.absolute()}{RESET}.\n"
         "`fetch` and `submit` functions will fail without a user token.\n"
-        f"See {YELLOW}README{RESET} for instructions on how to get your user token.\n"
+        f"See {YELLOW}README{RESET} for instructions on how to get your user token.\n",
     )
 
 
@@ -102,9 +102,10 @@ def fetch(year: int, day: int, open_with: Literal["vscode"] | None = None) -> st
     """
     _fix_old_inputs(year)
 
-    input_file = CONFIG_DIR / f"{year}" / f"{day:02}.txt"
-    if not input_file.parent.exists():
-        input_file.mkdir()
+    year_dir=CONFIG_DIR / f"{year}"
+    if not year_dir.exists():
+        year_dir.mkdir()
+    input_file = year_dir / f"{day:02}.txt"
 
     if input_file.exists():
         input_ = input_file.read_text()
@@ -125,13 +126,13 @@ def fetch(year: int, day: int, open_with: Literal["vscode"] | None = None) -> st
     if open_with is not None:
         # Open an issue to add a command to open the input file in your favorite editor.
         editors = {"vscode": ["code", "-r"]}
-        subprocess.run([*editors[open_with], input_file], shell=True)
+        subprocess.run([*editors[open_with], input_file], shell=True, check=False)
 
     return input_
 
 
 def submit(
-    year: int, day: int, part: Literal[1, 2], solution: Callable, sanity_check=True
+    year: int, day: int, part: Literal[1, 2], solution: Callable, sanity_check=True,
 ) -> None:
     """Submit a solution.
 
@@ -148,7 +149,7 @@ def submit(
     if "solution" in current:
         print(
             f"Day {day}, part {part} has already been solved. "
-            f"The solution was:\n{current['solution']}"
+            f"The solution was:\n{current['solution']}",
         )
         return
 
@@ -161,7 +162,7 @@ def submit(
     if answer in current:
         print(
             f"Solution {answer} to part {part} has already been submitted,"
-            " response was:"
+            " response was:",
         )
         _pretty_print(current[answer])
         return


### PR DESCRIPTION
OS: Windows 10, python 3.12

On a clean install, I tried to run a default template python file (year 2024, day 1). I encountered this error:

> Traceback (most recent call last):
>   File "c:\Users\guill\Documents\Python\Advent_Of_Code\2024\day_01.py", line 3, in 
> <module>
>     RAW = aoc_lube.fetch(year=2024, day=1)
>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "C:\Users\guill\Documents\Python\Advent_Of_Code\.venv\Lib\site-packages\aoc_lube\__init__.py", line 107, in fetch
>     input_file.mkdir()
>   File "C:\Users\guill\AppData\Local\Programs\Python\Python312\Lib\pathlib.py", line 1311, in mkdir
>     os.mkdir(self, mode)
> FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\Users\\guill\\.aoc_lube\\2024\\01.txt'

After investigating, I found that this error is raised because in the path `\\guill\\.aoc_lube\\2024\\01.txt`, both the .txt file and 2024 folder don't exist the first time it's run. If you check the[ python doc](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir):

> If parents is false (the default), a missing parent raises [FileNotFoundError](https://docs.python.org/3/library/exceptions.html#FileNotFoundError).

So I modified the fetch function to first check if a year folder exists and create it if necessary.
(line 105-108, you can ignore other changes, it's just formatting).

I tried with this new version and I have the countdown appearing in the terminal as expected.
